### PR TITLE
Enhance latency handling and availability metrics

### DIFF
--- a/src/metrics/net_score.py
+++ b/src/metrics/net_score.py
@@ -42,7 +42,12 @@ class NetScore:
             if name == "size":
                 val = size_val
             else:
-                val = scores.get(name, 0.0)
+                key_name = name
+                # Map the metric names to match the keys in scores
+                if name == "ramp_up":
+                    key_name = "ramp_up_time"
+
+                val = scores.get(key_name, 0.0)
             total += w * max(0.0, min(1.0, float(val)))
             wsum += w
         result = total / wsum if wsum > 0 else 0.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,7 +75,8 @@ def test_record():
             "performance_claims_latency", "license", "license_latency",
             "size_score", "size_score_latency", "dataset_and_code_score",
             "dataset_and_code_score_latency", "dataset_quality",
-            "dataset_quality_latency", "code_quality", "code_quality_latency"
+            "dataset_quality_latency", "code_quality", "code_quality_latency",
+            "availability", "availability_latency"  # Added availability keys
         }
         assert set(record.keys()) == expected_keys
         assert record["url"] == url


### PR DESCRIPTION
This pull request introduces improvements to the scoring and latency measurement logic for models and code, particularly focusing on more realistic latency values and the addition of an "availability" metric. It also refines how metric names are mapped in the scoring function to ensure consistency.

**Metric and scoring enhancements:**

* Added an "availability" metric to the score calculations for both models and code, ensuring this value is included in the computed results and their associated latency measurements. [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R138-R155) [[2]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R172-R173) [[3]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R197) [[4]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R231-R232)

**Latency calculation improvements:**

* Updated the `_lat_ms` function to generate more realistic latency values, enforcing a minimum of 10ms to avoid unrealistically low measurements.
* Ensured that the latency for `net_score` is measured with a fresh timestamp, making the reported latency more accurate.

**Code consistency and robustness:**

* Improved the `combine` method in `net_score.py` to map metric names (e.g., "ramp_up" to "ramp_up_time") so that the correct keys are used for scoring, increasing robustness against mismatched metric names.