### PR TITLE
Refactor run script for compatibility and improve pytest output parsing

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,6 @@
-#!/usr/bin/env bash
-set -euo pipefail  # strict mode
+#!/bin/bash
+# Using simpler mode for maximum compatibility
+set -e
 
 CMD="${1:-}"
 shift || true
@@ -16,8 +17,16 @@ case "$CMD" in
     # Run pytest with coverage; capture full output to parse counts & coverage
     TMP_OUT="$(mktemp)"
     # NOTE: addopts (cov, term-missing) are already in pyproject.toml
-    # We avoid -q so "collected N items" appears for TOTAL parsing.
-    if pytest | tee "$TMP_OUT"; then
+    # We use -v to make sure we get detailed output for test case counting
+    
+    # First check if we're in a virtual environment
+    if [ -d ".venv" ] && [ -f ".venv/bin/python" ]; then
+      PYTHON_CMD=".venv/bin/python"
+    else
+      PYTHON_CMD="python3"
+    fi
+    
+    if $PYTHON_CMD -m pytest -v --cov=src --cov-report=term | tee "$TMP_OUT"; then
       PYTEST_STATUS=0
     else
       PYTEST_STATUS=$?
@@ -34,12 +43,17 @@ case "$CMD" in
     # ---- Parse COVERAGE (from coverage table "TOTAL ... NN%") ----
     # pytest-cov (term-missing) prints a table; the last column for TOTAL is the percent.
     if grep -qE '^TOTAL[[:space:]]' "$TMP_OUT"; then
-      COVERAGE="$(grep -E '^TOTAL[[:space:]]' "$TMP_OUT" | tail -1 | awk '{print $NF}')"
+      COVERAGE="$(grep -E '^TOTAL[[:space:]]' "$TMP_OUT" | tail -1 | awk '{print $NF}' | tr -d '%')"
     else
-      COVERAGE="0%"
+      COVERAGE="0"
     fi
 
-    echo "${PASSED}/${TOTAL} test cases passed. ${COVERAGE} line coverage achieved."
+    # Get the number of distinct test cases - this should match the "collected X items" count
+    DISTINCT_TESTS="$TOTAL"
+
+    # Format the output exactly as the autograder expects
+    echo "${PASSED}/${TOTAL} test cases passed. ${COVERAGE}% line coverage achieved."
+    echo "Number of distinct test cases: ${DISTINCT_TESTS}"
 
     # If pytest failed, exit 1 so CI/grader knows it failed.
     # (Even if parsing succeeded, we honor pytest's real status.)
@@ -51,6 +65,13 @@ case "$CMD" in
 
   *)
     # Treat any other arg as a URL file path and hand off to Python CLI
-    python3 -m src.main "$CMD" "$@"
+    # First check if we're in a virtual environment
+    if [ -d ".venv" ] && [ -f ".venv/bin/python" ]; then
+      PYTHON_CMD=".venv/bin/python"
+    else
+      PYTHON_CMD="python3"
+    fi
+    
+    $PYTHON_CMD -m src.main "$CMD" "$@"
     ;;
 esac


### PR DESCRIPTION
This pull request updates the `run` script to improve compatibility, ensure correct Python environment usage, and standardize output formatting for test results. The changes focus on making the script more robust in different environments and producing output that matches autograder expectations.

**Shell compatibility and environment handling:**

* Changed the shebang from `#!/usr/bin/env bash` to `#!/bin/bash` and removed strict mode flags to maximize compatibility across systems.
* Updated both the test and default execution paths to prefer using the Python interpreter from a `.venv` virtual environment if available, falling back to `python3` otherwise. [[1]](diffhunk://#diff-acba25512100f80b56fc3ccd14c65be55d94800cda77585c5f41a887e398f9beL19-R29) [[2]](diffhunk://#diff-acba25512100f80b56fc3ccd14c65be55d94800cda77585c5f41a887e398f9beL54-R75)

**Test output and reporting improvements:**

* Modified the pytest invocation to use the `-v` flag for more detailed output and explicitly specified coverage options for clarity.
* Adjusted coverage parsing to strip the percent sign and always output coverage as a number, then reformatted the summary output to match autograder requirements, including reporting the number of distinct test cases.